### PR TITLE
Support HTML tags for Django 2.0

### DIFF
--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -9,7 +9,7 @@ from django.contrib.admin.views import main as main_views
 from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.encoding import force_text
-from django.utils.html import escape
+from django.utils.html import escape, mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from celery import current_app
@@ -40,6 +40,7 @@ class MonitorList(main_views.ChangeList):
         self.title = self.model_admin.list_page_title
 
 
+@mark_safe
 @display_field(_('state'), 'state')
 def colored_state(task):
     """Return the task state colored with HTML/CSS according to its level.
@@ -51,6 +52,7 @@ def colored_state(task):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('state'), 'last_heartbeat')
 def node_state(node):
     """Return the worker state colored with HTML/CSS according to its level.
@@ -62,6 +64,7 @@ def node_state(node):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('ETA'), 'eta')
 def eta(task):
     """Return the task ETA as a grey "none" if none is provided."""
@@ -70,6 +73,7 @@ def eta(task):
     return escape(make_aware(task.eta))
 
 
+@mark_safe
 @display_field(_('when'), 'tstamp')
 def tstamp(task):
     """Better timestamp rendering.
@@ -83,6 +87,7 @@ def tstamp(task):
     )
 
 
+@mark_safe
 @display_field(_('name'), 'name')
 def name(task):
     """Return the task name and abbreviates it to maximum of 16 characters."""

--- a/django_celery_monitor/utils.py
+++ b/django_celery_monitor/utils.py
@@ -9,7 +9,7 @@ from pprint import pformat
 from django.conf import settings
 from django.db.models import DateTimeField, Func
 from django.utils import timezone
-from django.utils.html import escape
+from django.utils.html import escape, mark_safe
 
 try:
     from django.db.models.functions import Now
@@ -109,4 +109,4 @@ def fixedwidth(field, name=None, pt=6, width=16, maxlen=64, pretty=False):
             escape(val[:255]), pt, escape(shortval),
         )
         return styled.replace('|br/|', '<br/>')
-    return f
+    return mark_safe(f)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     tests-py{py,27,34,35}-dj{18,19,110}
-    tests-py36-dj111
+    tests-py{py,27,34,35,36}-dj111
+    tests-py{34,35,36}-dj20
     apicheck
     builddocs
     flake8
@@ -28,6 +29,7 @@ deps=
     dj19: django>=1.9,<1.10
     dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2
+    dj20: django>=2.0,<2.1
 
     apicheck,builddocs,linkcheck: -r{toxinidir}/requirements/docs.txt
     flake8,flakeplus,manifest,pydocstyle,readme: -r{toxinidir}/requirements/pkgutils.txt


### PR DESCRIPTION
Fixes #39 

I took a much simpler approach to previous works on this. I simply added `mark_safe` to all of the html output, and then added Django 2.0 to the testing matrix. No more, no less. 😄 

I've also verified the output on a local Django 2.0.x application, but have not verified on any <2.0, as I don't actually have one to work with anymore...