### PR TITLE
mark_safe support for admin fields

### DIFF
--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -17,7 +17,7 @@ except ImportError:
     def mark_safe(func):
         def wrapper():
             func()
-    return wrapper
+        return wrapper
 
 
 from django.utils.translation import ugettext_lazy as _

--- a/django_celery_monitor/admin.py
+++ b/django_celery_monitor/admin.py
@@ -10,6 +10,16 @@ from django.shortcuts import render_to_response
 from django.template import RequestContext
 from django.utils.encoding import force_text
 from django.utils.html import escape
+
+try:
+    from django.utils.safestring import mark_safe
+except ImportError:
+    def mark_safe(func):
+        def wrapper():
+            func()
+    return wrapper
+
+
 from django.utils.translation import ugettext_lazy as _
 
 from celery import current_app
@@ -40,6 +50,7 @@ class MonitorList(main_views.ChangeList):
         self.title = self.model_admin.list_page_title
 
 
+@mark_safe
 @display_field(_('state'), 'state')
 def colored_state(task):
     """Return the task state colored with HTML/CSS according to its level.
@@ -51,6 +62,7 @@ def colored_state(task):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('state'), 'last_heartbeat')
 def node_state(node):
     """Return the worker state colored with HTML/CSS according to its level.
@@ -62,6 +74,7 @@ def node_state(node):
     return '<b><span style="color: {0};">{1}</span></b>'.format(color, state)
 
 
+@mark_safe
 @display_field(_('ETA'), 'eta')
 def eta(task):
     """Return the task ETA as a grey "none" if none is provided."""
@@ -70,6 +83,7 @@ def eta(task):
     return escape(make_aware(task.eta))
 
 
+@mark_safe
 @display_field(_('when'), 'tstamp')
 def tstamp(task):
     """Better timestamp rendering.
@@ -83,6 +97,7 @@ def tstamp(task):
     )
 
 
+@mark_safe
 @display_field(_('name'), 'name')
 def name(task):
     """Return the task name and abbreviates it to maximum of 16 characters."""


### PR DESCRIPTION
The HTML for display in the admin fields was getting escaped in Django 2.0+. Fix is backward compatible with Django 1.x and Python 2.7